### PR TITLE
Observaciones unidades rrhh

### DIFF
--- a/src/app/empleadores/unidad/(componentes)/modal-editar-unidad.tsx
+++ b/src/app/empleadores/unidad/(componentes)/modal-editar-unidad.tsx
@@ -514,7 +514,17 @@ const ModalEditarUnidad: React.FC<ModalEditarUnidadProps> = ({
           <Modal.Footer>
             <div className="w-100 d-flex flex-column flex-md-row flex-md-row-reverse">
               <button type="submit" className="btn btn-primary">
-                Grabar
+                Grabar &nbsp;
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  fill="currentColor"
+                  className="bi bi-floppy"
+                  viewBox="0 0 16 16">
+                  <path d="M11 2H9v3h2V2Z" />
+                  <path d="M1.5 0h11.586a1.5 1.5 0 0 1 1.06.44l1.415 1.414A1.5 1.5 0 0 1 16 2.914V14.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13A1.5 1.5 0 0 1 1.5 0ZM1 1.5v13a.5.5 0 0 0 .5.5H2v-4.5A1.5 1.5 0 0 1 3.5 9h9a1.5 1.5 0 0 1 1.5 1.5V15h.5a.5.5 0 0 0 .5-.5V2.914a.5.5 0 0 0-.146-.353l-1.415-1.415A.5.5 0 0 0 13.086 1H13v4.5A1.5 1.5 0 0 1 11.5 7h-7A1.5 1.5 0 0 1 3 5.5V1H1.5a.5.5 0 0 0-.5.5Zm3 4a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5V1H4v4.5ZM3 15h10v-4.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5V15Z" />
+                </svg>
               </button>
               <button
                 type="button"

--- a/src/app/empleadores/unidad/(componentes)/modal-editar-unidad.tsx
+++ b/src/app/empleadores/unidad/(componentes)/modal-editar-unidad.tsx
@@ -119,6 +119,7 @@ const ModalEditarUnidad: React.FC<ModalEditarUnidadProps> = ({
       });
 
       refrescarPagina();
+      cerrarModalEditarRRHH();
 
       onUnidadRRHHEditada();
     } catch (error) {
@@ -132,6 +133,7 @@ const ModalEditarUnidad: React.FC<ModalEditarUnidadProps> = ({
       });
     } finally {
       setMostrarSpinner(false);
+      cerrarModalEditarRRHH();
     }
   };
 
@@ -325,7 +327,7 @@ const ModalEditarUnidad: React.FC<ModalEditarUnidadProps> = ({
 
                 <div className="col-12 col-lg-6 col-xl-3 position-relative">
                   <label className="form-label" htmlFor="numero">
-                    N° Calle (*)
+                    Número (*)
                   </label>
                   <input
                     id="numero"
@@ -362,7 +364,7 @@ const ModalEditarUnidad: React.FC<ModalEditarUnidadProps> = ({
 
                 <div className="col-12 col-lg-6 col-xl-3 position-relative">
                   <label className="form-label" htmlFor="departamento">
-                    N° casa/Departamento
+                    Departamento
                   </label>
                   <input
                     id="departamento"

--- a/src/app/empleadores/unidad/(componentes)/modal-editar-unidad.tsx
+++ b/src/app/empleadores/unidad/(componentes)/modal-editar-unidad.tsx
@@ -514,13 +514,13 @@ const ModalEditarUnidad: React.FC<ModalEditarUnidadProps> = ({
           <Modal.Footer>
             <div className="w-100 d-flex flex-column flex-md-row flex-md-row-reverse">
               <button type="submit" className="btn btn-primary">
-                Modificar
+                Grabar
               </button>
               <button
                 type="button"
                 className="btn btn-danger   mt-2 mt-md-0 me-0 me-md-2"
                 onClick={cerrarModalEditarRRHH}>
-                Cancelar
+                Salir
               </button>
             </div>
           </Modal.Footer>

--- a/src/app/empleadores/unidad/(componentes)/modal-nueva-unidad.tsx
+++ b/src/app/empleadores/unidad/(componentes)/modal-nueva-unidad.tsx
@@ -288,7 +288,7 @@ const ModalNuevaUnidad: React.FC<ModalNuevaUnidadProps> = ({
 
                     <div className="col-12 col-lg-6 col-xl-3 position-relative">
                       <label className="form-label" htmlFor="numero">
-                        N° Calle (*)
+                        Número (*)
                       </label>
                       <input
                         id="numero"
@@ -325,7 +325,7 @@ const ModalNuevaUnidad: React.FC<ModalNuevaUnidadProps> = ({
 
                     <div className="col-12 col-lg-6 col-xl-3 position-relative">
                       <label className="form-label" htmlFor="departamento">
-                        N° casa/Departamento
+                        Departamento
                       </label>
                       <input
                         id="departamento"

--- a/src/app/empleadores/unidad/(componentes)/modal-nueva-unidad.tsx
+++ b/src/app/empleadores/unidad/(componentes)/modal-nueva-unidad.tsx
@@ -464,7 +464,17 @@ const ModalNuevaUnidad: React.FC<ModalNuevaUnidadProps> = ({
               <div className="modal-footer">
                 <div className="w-100 d-flex flex-column flex-md-row flex-md-row-reverse">
                   <button type="submit" className="btn btn-primary">
-                    Grabar
+                    Grabar &nbsp;
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                      className="bi bi-floppy"
+                      viewBox="0 0 16 16">
+                      <path d="M11 2H9v3h2V2Z" />
+                      <path d="M1.5 0h11.586a1.5 1.5 0 0 1 1.06.44l1.415 1.414A1.5 1.5 0 0 1 16 2.914V14.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13A1.5 1.5 0 0 1 1.5 0ZM1 1.5v13a.5.5 0 0 0 .5.5H2v-4.5A1.5 1.5 0 0 1 3.5 9h9a1.5 1.5 0 0 1 1.5 1.5V15h.5a.5.5 0 0 0 .5-.5V2.914a.5.5 0 0 0-.146-.353l-1.415-1.415A.5.5 0 0 0 13.086 1H13v4.5A1.5 1.5 0 0 1 11.5 7h-7A1.5 1.5 0 0 1 3 5.5V1H1.5a.5.5 0 0 0-.5.5Zm3 4a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5V1H4v4.5ZM3 15h10v-4.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5V15Z" />
+                    </svg>
                   </button>
                   <button
                     type="button"

--- a/src/app/empleadores/unidad/(componentes)/modal-nueva-unidad.tsx
+++ b/src/app/empleadores/unidad/(componentes)/modal-nueva-unidad.tsx
@@ -464,7 +464,7 @@ const ModalNuevaUnidad: React.FC<ModalNuevaUnidadProps> = ({
               <div className="modal-footer">
                 <div className="w-100 d-flex flex-column flex-md-row flex-md-row-reverse">
                   <button type="submit" className="btn btn-primary">
-                    Guardar
+                    Grabar
                   </button>
                   <button
                     type="button"


### PR DESCRIPTION
Modales Editar/Crear unidad
En datos entidades empleadoras, al ir a la empresa, en la sección unidad al momento de agregar una unidad nueva, el modal debe contener lo siguiente: "Calle, Número, Departamento" en lugar de "Calle, N° Calle, N° casa/departamento"
Homologar los botones: Salir, Cancelar dejarlo como "Volver", Actualizar/Crear dejarlo como "Grabar"
¿Agregarle icono de disquete a los botones de grabar?
Al editar una unidad, se debe cerrar el modal